### PR TITLE
Push chunks on next tick

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 var from = require('from2');
 
-module.exports = function (x) {
+module.exports = function (x, opts) {
+	opts = opts || {};
+
 	if (Array.isArray(x)) {
 		x = x.slice();
 	}
@@ -19,11 +21,14 @@ module.exports = function (x) {
 
 		var chunk = x.slice(0, size);
 		x = x.slice(size);
-		cb(null, chunk);
+
+		setImmediate(cb, null, chunk);
 	});
 };
 
-module.exports.obj = function (x) {
+module.exports.obj = function (x, opts) {
+	opts = opts || {};
+
 	if (Array.isArray(x)) {
 		x = x.slice();
 	}
@@ -40,6 +45,7 @@ module.exports.obj = function (x) {
 		}
 
 		this.push(x);
-		cb(null, null);
+
+		setImmediate(cb, null, null);
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,6 @@ Adheres to the requested chunk size, except for `array` where each element will 
 Type: `object`, `array<object>`<br>
 Returns: [Readable object stream](https://nodejs.org/api/stream.html#stream_object_mode)
 
-
 ## License
 
 MIT © [Sindre Sorhus](https://sindresorhus.com)

--- a/test.js
+++ b/test.js
@@ -25,3 +25,17 @@ test('object mode', async t => {
 	const f2 = [{foo: true}, {bar: true}];
 	t.deepEqual(await getStream.array(m.obj(f2)), f2);
 });
+
+test.cb('pushes chunk on next frame', t => {
+	const f = new Buffer(fixture);
+	let flag = false;
+
+	setImmediate(() => {
+		flag = true;
+	});
+
+	m(f).on('data', function () {
+		t.truthy(flag);
+		t.end();
+	});
+});


### PR DESCRIPTION
This flag is useful for splitting computation on big buffers. 

For example (if we forced to use Buffer) with [hasha](github.com/sindresorhus/hasha):

```js
hasha(bigBuffer) // Locks event-loop

await hasha.fromStream(intoStream(bigBuffer)); // Server can serve requests
```