### PR TITLE
Add promise support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,37 @@
 'use strict';
 const from = require('from2');
+const isPromise = require('is-promise');
 
 module.exports = x => {
 	if (Array.isArray(x)) {
 		x = x.slice();
 	}
 
-	// We don't iterate on strings and buffers since slicing them is ~7x faster
-	const shouldIterate = x[Symbol.iterator] && typeof x !== 'string' && !Buffer.isBuffer(x);
-	const iterator = shouldIterate ? x[Symbol.iterator]() : null;
+	let pendingPromise = isPromise(x) ? x : null;
+	let shouldIterate;
+	let iterator;
 
-	return from((size, cb) => {
+	if (!pendingPromise) {
+		decideIteration();
+	}
+
+	function decideIteration() {
+		// We don't iterate on strings and buffers since slicing them is ~7x faster.
+		shouldIterate = x[Symbol.iterator] && typeof x !== 'string' && !Buffer.isBuffer(x);
+		iterator = shouldIterate ? x[Symbol.iterator]() : null;
+	}
+
+	return from(function reader(size, cb) {
+		if (pendingPromise) {
+			pendingPromise.then(result => {
+				x = result;
+				pendingPromise = null;
+				decideIteration();
+				reader.call(this, size, cb);
+			}, cb);
+			return;
+		}
+
 		if (shouldIterate) {
 			const obj = iterator.next();
 			setImmediate(cb, null, obj.done ? null : obj.value);
@@ -34,9 +55,28 @@ module.exports.obj = x => {
 		x = x.slice();
 	}
 
-	const iterator = x[Symbol.iterator] ? x[Symbol.iterator]() : null;
+	let pendingPromise = isPromise(x) ? x : null;
+	let iterator;
 
-	return from.obj(function (size, cb) {
+	if (!pendingPromise) {
+		decideIteration();
+	}
+
+	function decideIteration() {
+		iterator = x[Symbol.iterator] ? x[Symbol.iterator]() : null;
+	}
+
+	return from.obj(function reader(size, cb) {
+		if (pendingPromise) {
+			pendingPromise.then(result => {
+				x = result;
+				pendingPromise = null;
+				decideIteration();
+				reader.call(this, size, cb);
+			}, cb);
+			return;
+		}
+
 		if (iterator) {
 			const obj = iterator.next();
 			setImmediate(cb, null, obj.done ? null : obj.value);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "str"
   ],
   "dependencies": {
-    "from2": "^2.1.1"
+    "from2": "^2.1.1",
+    "is-promise": "^2.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -26,14 +26,14 @@ intoStream('unicorn').pipe(process.stdout);
 
 ### intoStream(input)
 
-Type: `Buffer` `string` `Iterable<Buffer|string>`<br>
+Type: `Buffer` `string` `Iterable<Buffer|string>` `Promise`<br>
 Returns: [Readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 Adheres to the requested chunk size, except for `array` where each element will be a chunk.
 
 ### intoStream.obj(input)
 
-Type: `Object`, `Iterable<Object>`<br>
+Type: `Object`, `Iterable<Object>` `Promise`<br>
 Returns: [Readable object stream](https://nodejs.org/api/stream.html#stream_object_mode)
 
 

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ const fixture = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenea
 
 function iterableFrom(arr) {
 	return {
-		[Symbol.iterator]: function *() {
+		[Symbol.iterator]: function * () {
 			let i = 0;
 			while (i < arr.length) {
 				yield arr[i++];

--- a/test.js
+++ b/test.js
@@ -5,6 +5,17 @@ import m from './';
 
 const fixture = 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium.';
 
+function iterableFrom(arr) {
+	return {
+		[Symbol.iterator]: function *() {
+			let i = 0;
+			while (i < arr.length) {
+				yield arr[i++];
+			}
+		}
+	};
+}
+
 test('string', async t => {
 	t.is(await getStream(m(fixture)), fixture);
 });
@@ -19,16 +30,29 @@ test('array', async t => {
 });
 
 test('iterable', async t => {
-	const iterable = {
-		val: fixture.split(''),
-		[Symbol.iterator]: function *() {
-			let i = 0;
-			while (i < this.val.length) {
-				yield this.val[i++];
-			}
-		}
-	};
+	const iterable = iterableFrom(fixture.split(''));
 	t.is(await getStream(m(iterable)), fixture);
+});
+
+test('promise', async t => {
+	const promise = new Promise(resolve => {
+		setImmediate(resolve.bind(null, fixture));
+	});
+	t.is(await getStream(m(promise)), fixture);
+});
+
+test('promise resolving to iterable', async t => {
+	const promise = new Promise(resolve => {
+		setImmediate(resolve.bind(null, iterableFrom(fixture.split(''))));
+	});
+	t.is(await getStream(m(promise)), fixture);
+});
+
+test('stream errors when promise rejects', async t => {
+	const promise = new Promise((resolve, reject) => {
+		setImmediate(reject.bind(null, new Error('test error')));
+	});
+	await t.throws(getStream(m(promise)), 'test error');
 });
 
 test('object mode', async t => {
@@ -40,16 +64,38 @@ test('object mode', async t => {
 });
 
 test('object mode from iterable', async t => {
-	const iterable = {
-		val: [{foo: true}, {bar: true}],
-		[Symbol.iterator]: function *() {
-			let i = 0;
-			while (i < this.val.length) {
-				yield this.val[i++];
-			}
-		}
-	};
-	t.deepEqual(await getStream.array(m.obj(iterable)), iterable.val);
+	const values = [{foo: true}, {bar: true}];
+	const iterable = iterableFrom(values);
+	t.deepEqual(await getStream.array(m.obj(iterable)), values);
+});
+
+test('object mode from promise', async t => {
+	const f = {foo: true};
+	const promise = new Promise(resolve => {
+		setImmediate(resolve.bind(null, f));
+	});
+	t.deepEqual(await getStream.array(m.obj(promise)), [f]);
+
+	const f2 = [{foo: true}, {bar: true}];
+	const promise2 = new Promise(resolve => {
+		setImmediate(resolve.bind(null, f2));
+	});
+	t.deepEqual(await getStream.array(m.obj(promise2)), f2);
+});
+
+test('object mode from promise resolving to iterable', async t => {
+	const values = [{foo: true}, {bar: true}];
+	const promise = new Promise(resolve => {
+		setImmediate(resolve.bind(null, iterableFrom([{foo: true}, {bar: true}])));
+	});
+	t.deepEqual(await getStream.array(m.obj(promise)), values);
+});
+
+test('object mode errors when promise rejects', async t => {
+	const promise = new Promise((resolve, reject) => {
+		setImmediate(reject.bind(null, new Error('test error')));
+	});
+	await t.throws(getStream.array(m.obj(promise)), 'test error');
 });
 
 test.cb('pushes chunk on next tick', t => {


### PR DESCRIPTION
Adds transparent promise support for both normal and object mode streams.

When promise rejects, the error is passed to the stream to be emitted.
### Examples:

``` js
const promise = new Promise(resolve => resolve('foo'));
t.is(await getStream(intoStream(promise)), 'foo');
```

Object mode:

``` js
const f = [{foo: true}, {bar: true}];
const promise = new Promise(resolve => resolve(f));
t.deepEqual(await getStream.array(intoStream.obj(promise)), f);
```
