### PR TITLE
Add iterable support

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,19 @@ module.exports = x => {
 		x = x.slice();
 	}
 
-	const iterate = x[Symbol.iterator] && typeof x !== 'string' && !Buffer.isBuffer(x);
-	const iterator = iterate ? x[Symbol.iterator]() : null;
+	// We don't iterate on strings and buffers since slicing them is ~7x faster.
+	const shouldIterate = x[Symbol.iterator] && typeof x !== 'string' && !Buffer.isBuffer(x);
+	const iterator = shouldIterate ? x[Symbol.iterator]() : null;
 
 	return from((size, cb) => {
-		if (iterate) {
+		if (shouldIterate) {
 			const obj = iterator.next();
 			setImmediate(cb, null, obj.done ? null : obj.value);
 			return;
 		}
 
 		if (x.length === 0) {
-			cb(null, null);
+			setImmediate(cb, null, null);
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,23 @@
 'use strict';
 const from = require('from2');
+const isIterable = require('is-iterable');
 
 module.exports = x => {
+	let iterator;
+
 	if (Array.isArray(x)) {
 		x = x.slice();
+	} else if (!(x && x.slice) && isIterable(x)) {
+		iterator = x[Symbol.iterator]();
 	}
 
 	return from((size, cb) => {
+		if (iterator) {
+			let obj = iterator.next();
+			cb(null, obj.done ? null : obj.value);
+			return;
+		}
+
 		if (x.length === 0) {
 			cb(null, null);
 			return;
@@ -25,11 +36,21 @@ module.exports = x => {
 };
 
 module.exports.obj = x => {
+	let iterator;
+
 	if (Array.isArray(x)) {
 		x = x.slice();
+	} else if (isIterable(x)) {
+		iterator = x[Symbol.iterator]();
 	}
 
 	return from.obj(function (size, cb) {
+		if (iterator) {
+			let obj = iterator.next();
+			cb(null, obj.done ? null : obj.value);
+			return;
+		}
+
 		if (Array.isArray(x)) {
 			if (x.length === 0) {
 				cb(null, null);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = x => {
 	return from((size, cb) => {
 		if (iterate) {
 			const obj = iterator.next();
-			cb(null, obj.done ? null : obj.value);
+			setImmediate(cb, null, obj.done ? null : obj.value);
 			return;
 		}
 
@@ -38,7 +38,7 @@ module.exports.obj = x => {
 	return from.obj(function (size, cb) {
 		if (iterator) {
 			const obj = iterator.next();
-			cb(null, obj.done ? null : obj.value);
+			setImmediate(cb, null, obj.done ? null : obj.value);
 			return;
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,30 +1,23 @@
 'use strict';
 const from = require('from2');
-const isIterable = require('is-iterable');
 
 module.exports = x => {
-	let iterator;
-
 	if (Array.isArray(x)) {
 		x = x.slice();
-	} else if (!(x && x.slice) && isIterable(x)) {
-		iterator = x[Symbol.iterator]();
 	}
 
+	const iterate = x[Symbol.iterator] && typeof x !== 'string' && !Buffer.isBuffer(x);
+	const iterator = iterate ? x[Symbol.iterator]() : null;
+
 	return from((size, cb) => {
-		if (iterator) {
-			let obj = iterator.next();
+		if (iterate) {
+			const obj = iterator.next();
 			cb(null, obj.done ? null : obj.value);
 			return;
 		}
 
 		if (x.length === 0) {
 			cb(null, null);
-			return;
-		}
-
-		if (Array.isArray(x)) {
-			cb(null, x.shift());
 			return;
 		}
 
@@ -36,28 +29,16 @@ module.exports = x => {
 };
 
 module.exports.obj = x => {
-	let iterator;
-
 	if (Array.isArray(x)) {
 		x = x.slice();
-	} else if (isIterable(x)) {
-		iterator = x[Symbol.iterator]();
 	}
+
+	const iterator = x[Symbol.iterator] ? x[Symbol.iterator]() : null;
 
 	return from.obj(function (size, cb) {
 		if (iterator) {
-			let obj = iterator.next();
+			const obj = iterator.next();
 			cb(null, obj.done ? null : obj.value);
-			return;
-		}
-
-		if (Array.isArray(x)) {
-			if (x.length === 0) {
-				cb(null, null);
-				return;
-			}
-
-			cb(null, x.shift());
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "str"
   ],
   "dependencies": {
-    "from2": "^2.1.1"
+    "from2": "^2.1.1",
+    "is-iterable": "^1.1.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "str"
   ],
   "dependencies": {
-    "from2": "^2.1.1",
-    "is-iterable": "^1.1.0"
+    "from2": "^2.1.1"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -26,14 +26,14 @@ intoStream('unicorn').pipe(process.stdout);
 
 ### intoStream(input)
 
-Type: `Buffer` `string` `Array<Buffer|string>`<br>
+Type: `Buffer` `string` `Array<Buffer|string>` `Iterable`<br>
 Returns: [Readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 Adheres to the requested chunk size, except for `array` where each element will be a chunk.
 
 ### intoStream.obj(input)
 
-Type: `object`, `array<object>`<br>
+Type: `object`, `array<object>` `Iterable`<br>
 Returns: [Readable object stream](https://nodejs.org/api/stream.html#stream_object_mode)
 
 

--- a/readme.md
+++ b/readme.md
@@ -26,14 +26,14 @@ intoStream('unicorn').pipe(process.stdout);
 
 ### intoStream(input)
 
-Type: `Buffer` `string` `Array<Buffer|string>` `Iterable`<br>
+Type: `Buffer` `string` `Iterable<Buffer|string>`<br>
 Returns: [Readable stream](https://nodejs.org/api/stream.html#stream_class_stream_readable)
 
 Adheres to the requested chunk size, except for `array` where each element will be a chunk.
 
 ### intoStream.obj(input)
 
-Type: `object`, `array<object>` `Iterable`<br>
+Type: `object`, `Iterable<object>`<br>
 Returns: [Readable object stream](https://nodejs.org/api/stream.html#stream_object_mode)
 
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Adheres to the requested chunk size, except for `array` where each element will 
 
 ### intoStream.obj(input)
 
-Type: `object`, `Iterable<object>`<br>
+Type: `object`, `Iterable<Object>`<br>
 Returns: [Readable object stream](https://nodejs.org/api/stream.html#stream_object_mode)
 
 

--- a/test.js
+++ b/test.js
@@ -18,12 +18,38 @@ test('array', async t => {
 	t.is(await getStream(m(fixture.split(''))), fixture);
 });
 
+test('iterable', async t => {
+	const iterable = {
+		val: fixture.split(''),
+		[Symbol.iterator]: function *() {
+			let i = 0;
+			while (i < this.val.length) {
+				yield this.val[i++];
+			}
+		}
+	};
+	t.is(await getStream(m(iterable)), fixture);
+});
+
 test('object mode', async t => {
 	const f = {foo: true};
 	t.deepEqual(await getStream.array(m.obj(f)), [f]);
 
 	const f2 = [{foo: true}, {bar: true}];
 	t.deepEqual(await getStream.array(m.obj(f2)), f2);
+});
+
+test('object mode from iterable', async t => {
+	const iterable = {
+		val: [{foo: true}, {bar: true}],
+		[Symbol.iterator]: function *() {
+			let i = 0;
+			while (i < this.val.length) {
+				yield this.val[i++];
+			}
+		}
+	};
+	t.deepEqual(await getStream.array(m.obj(iterable)), iterable.val);
 });
 
 test.cb('pushes chunk on next tick', t => {


### PR DESCRIPTION
Adds transparent iterable support.

### Examples:

```js
const set = new Set(['foo', 'bar']);
t.is(await getStream(intoStream(set)), 'foobar');
```

Object mode:

```js
const f = [{foo: true}, {bar: true}];
const set = new Set(f);
t.deepEqual(await getStream.array(intoStream.obj(set)), f);
```