### PR TITLE
fix: prevent using mocked setImmediate

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 const from = require('from2');
 const pIsPromise = require('p-is-promise');
 
+const {setImmediate} = global; // Avoid conflicts with sinon.useFakeTimers
+
 module.exports = input => {
 	if (Array.isArray(input)) {
 		input = input.slice();


### PR DESCRIPTION
sinon.useFakeTimers mocks global.setImmediate so I propose to store a link to non-mocked version to avoid this

it's really weird to debug this stuff and no reason to mock this in real word
if there are cases when someone will need this he or she can still require into-stream AFTER mocking timers