### PR TITLE
Allow arrays of arrays in `intoStream.object` TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node"/>
 import {Readable as ReadableStream} from 'stream';
 
+type Object = {[key: string]: any};
 declare namespace intoStream {
 	type Input =
 		| Buffer
@@ -10,8 +11,8 @@ declare namespace intoStream {
 		| Iterable<Buffer | string>;
 
 	type InputObject =
-		| {[key: string]: any}
-		| Iterable<any>;
+		| Object
+		| Iterable<Object | Object[]>;
 }
 
 declare const intoStream: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="node"/>
 import {Readable as ReadableStream} from 'stream';
 
-type Object = {[key: string]: any};
 declare namespace intoStream {
 	type Input =
 		| Buffer
@@ -11,8 +10,8 @@ declare namespace intoStream {
 		| Iterable<Buffer | string>;
 
 	type InputObject =
-		| Object
-		| Iterable<Object | Object[]>;
+		| object
+		| Iterable<object>;
 }
 
 declare const intoStream: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace intoStream {
 
 	type InputObject =
 		| {[key: string]: any}
-		| Iterable<{[key: string]: any}>;
+		| Iterable<any>;
 }
 
 declare const intoStream: {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -25,10 +25,13 @@ intoStream(Promise.resolve(new Uint8Array(Buffer.from('unicorn').buffer))).pipe(
 const object = {foo: true};
 const objectArray = new Set([object, {bar: true}]);
 const objectIterable = new Set(objectArray);
+const arrayOfArrays = [[object]];
 
 intoStream.object(object).pipe(process.stdout);
 intoStream.object(objectArray).pipe(process.stdout);
 intoStream.object(objectIterable).pipe(process.stdout);
+intoStream.object(arrayOfArrays).pipe(process.stdout);
 intoStream.object(Promise.resolve(object)).pipe(process.stdout);
 intoStream.object(Promise.resolve(objectArray)).pipe(process.stdout);
 intoStream.object(Promise.resolve(objectIterable)).pipe(process.stdout);
+intoStream.object(Promise.resolve(arrayOfArrays)).pipe(process.stdout);


### PR DESCRIPTION
I'm streaming arrays arrays of objects. Which works in the underlying library but the types don't currently reflect this.

```js
const arr = [{a:1}, {a:2}];
intoStream.object([arr, arr])
```
I used `any`, but let me know if you would like it to be more restrictive. 

Thanks for all your great libraries!